### PR TITLE
Linter prettier

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+ignore = E203, E266, E501, W503, F403, F401
+max-line-length = 79
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 23.3.0
+    hooks:
+    - id: black
+      language_version: python3.9
+-   repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+    - id: flake8

--- a/README.md
+++ b/README.md
@@ -29,3 +29,12 @@ Para demostrar el funcionamiento ejecutar:
 	flask --app main run
 
 ```
+
+## Uso de pre-commit
+
+Para mantener un codigo ordenado y dentro de los estanderes PEP, necesitamos utilizar pre-commit, por lo cual luego de instalar los requeriments, debemos ejecutar:
+
+```bash
+        pre-commit install
+
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.black]
+line-length = 79
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''

--- a/requeriments.txt
+++ b/requeriments.txt
@@ -6,3 +6,4 @@ Jinja2==3.1.2
 MarkupSafe==2.1.2
 Werkzeug==2.2.3
 zipp==3.15.0
+pre-commit==3.2.2


### PR DESCRIPTION
# Herramientas para mantener un código sanitizado [link ](https://ljvmiranda921.github.io/notebook/2018/06/21/precommits-using-black-and-flake8/)
Instalación de pre-commit para agregar hook antes de comitear que chequea:
   - Linter para código (black8)
   - chequeo de estándar PEP en el código(flake8)